### PR TITLE
fix: modify execution order in setup script for container

### DIFF
--- a/.github/workflows/continuous-release.yml
+++ b/.github/workflows/continuous-release.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           make setup-continuous-release
       - name: Run Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           make run-continuous-release
-        env:
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN  }}

--- a/scripts/pipeline/setup_continuous_integration.sh
+++ b/scripts/pipeline/setup_continuous_integration.sh
@@ -17,9 +17,6 @@ set -uo pipefail
 
 # Constant variables
 
-readonly -a GO_PACKAGES=(
-  github.com/golangci/golangci-lint/cmd/golangci-lint@latest
-)
 readonly -a APT_PACKAGES=(
   software-properties-common
   build-essential
@@ -70,36 +67,25 @@ readonly -a NPM_PACKAGES=(
   remark-lint-emphasis-marker
   remark-lint-strong-marker
 )
+readonly -a GO_PACKAGES=(
+  github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+)
 readonly -a CURL_PACKAGES=(
   "https://webinstall.dev/shfmt"
 )
 
 # Internal functions
 
-post_cleanup() {
-  local -i result=0
-
-  cleanup_apt
-  ((result |= $?))
-
-  cleanup_npm
-  ((result |= $?))
-
-  monitor "setup" "post-cleanup" "${result}"
-
-  return "${result}"
-}
-
 setup_continuous_integration() {
   local -i result=0
+
+  setup_apt_packages "${APT_PACKAGES[@]}"
+  ((result |= $?))
 
   setup_go_packages "${GO_PACKAGES[@]}"
   ((result |= $?))
 
   setup_curl_packages "${CURL_PACKAGES[@]}"
-  ((result |= $?))
-
-  setup_apt_packages "${APT_PACKAGES[@]}"
   ((result |= $?))
 
   setup_pip_packages "${PIP_PACKAGES[@]}"
@@ -108,7 +94,10 @@ setup_continuous_integration() {
   setup_npm_packages "${NPM_PACKAGES[@]}"
   ((result |= $?))
 
-  post_cleanup
+  cleanup_apt
+  ((result |= $?))
+
+  cleanup_npm
   ((result |= $?))
 
   return "${result}"

--- a/scripts/pipeline/setup_continuous_release.sh
+++ b/scripts/pipeline/setup_continuous_release.sh
@@ -36,20 +36,6 @@ readonly -a NPM_PACKAGES=(
 
 # Internal functions
 
-post_cleanup() {
-  local -i result=0
-
-  cleanup_apt
-  ((result |= $?))
-
-  cleanup_npm
-  ((result |= $?))
-
-  monitor "setup" "post-cleanup" "${result}"
-
-  return "${result}"
-}
-
 setup_continuous_release() {
   local -i result=0
 
@@ -59,7 +45,10 @@ setup_continuous_release() {
   setup_npm_packages "${NPM_PACKAGES[@]}"
   ((result |= $?))
 
-  post_cleanup
+  cleanup_apt
+  ((result |= $?))
+
+  cleanup_npm
   ((result |= $?))
 
   return "${result}"

--- a/scripts/pipeline/setup_continuous_testing.sh
+++ b/scripts/pipeline/setup_continuous_testing.sh
@@ -25,24 +25,13 @@ readonly -a APT_PACKAGES=(
 
 # Internal functions
 
-post_cleanup() {
-  local -i result=0
-
-  cleanup_apt
-  ((result |= $?))
-
-  monitor "setup" "post-cleanup" "${result}"
-
-  return "${result}"
-}
-
 setup_continuous_testing() {
   local -i result=0
 
   setup_apt_packages "${APT_PACKAGES[@]}"
   ((result |= $?))
 
-  post_cleanup
+  cleanup_apt
   ((result |= $?))
 
   return "${result}"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -31,24 +31,13 @@ readonly -a APT_PACKAGES=(
 
 # Internal functions
 
-post_cleanup() {
-  local -i result=0
-
-  cleanup_apt
-  ((result |= $?))
-
-  monitor "install" "post-cleanup" "${result}"
-
-  return "${result}"
-}
-
 setup() {
   local -i result=0
 
   setup_apt_packages "${APT_PACKAGES[@]}"
   ((result |= $?))
 
-  post_cleanup
+  cleanup_apt
   ((result |= $?))
 
   return "${result}"

--- a/scripts/utils/README.md
+++ b/scripts/utils/README.md
@@ -4,7 +4,7 @@
   > An internal library for git actions.
 
 - utils.sh
-  > An internal library for package management actions.
+  > An internal library for utility actions (e.g. package management).
 
 - fs.sh
   > An external library for file system actions from [bash-libraries](https://github.com/juan131/bash-libraries) repository.

--- a/scripts/utils/util.sh
+++ b/scripts/utils/util.sh
@@ -51,17 +51,18 @@ setup_apt_packages() {
   local -a packages=("$@")
 
   local -i retval=0
-  for package in "${packages[@]}"; do
-    local -i result=0
+  local -i result=0
 
+  for package in "${packages[@]}"; do
     update_apt
 
     install_apt "${package}"
     ((result = $?))
-    ((retval |= "${result}"))
 
     monitor "setup" "${package}" "${result}"
   done
+
+  ((retval |= "${result}"))
 
   return "${retval}"
 }
@@ -99,6 +100,8 @@ cleanup_apt() {
   sudo rm -rf /var/lib/apt/lists/*
   ((result |= $?))
 
+  monitor "cleanup" "apt" "${result}"
+
   return "${result}"
 }
 
@@ -132,15 +135,16 @@ setup_pip_packages() {
   local -a packages=("$@")
 
   local -i retval=0
-  for package in "${packages[@]}"; do
-    local -i result=0
+  local -i result=0
 
+  for package in "${packages[@]}"; do
     install_pip "${package}"
     ((result = $?))
-    ((retval |= "${result}"))
 
     monitor "setup" "${package}" "${result}"
   done
+
+  ((retval |= "${result}"))
 
   return "${retval}"
 }
@@ -175,18 +179,19 @@ setup_go_packages() {
   local -a packages=("$@")
 
   local -i retval=0
-  for package in "${packages[@]}"; do
-    local -i result=0
+  local -i result=0
 
+  for package in "${packages[@]}"; do
     # HACK(AK) https://github.com/actions/setup-go/issues/14
     export PATH="${HOME}"/go/bin:/usr/local/go/bin:"${PATH}"
 
     install_go "${package}"
     ((result = $?))
-    ((retval |= "${result}"))
 
     monitor "setup" "${package}" "${result}"
   done
+
+  ((retval |= "${result}"))
 
   return "${retval}"
 }
@@ -221,17 +226,18 @@ setup_curl_packages() {
   local -a packages=("$@")
 
   local -i retval=0
-  for package in "${packages[@]}"; do
-    local -i result=0
+  local -i result=0
 
+  for package in "${packages[@]}"; do
     export PATH="${HOME}"/.local/bin:"${PATH}"
 
     install_curl "${package}"
     ((result = $?))
-    ((retval |= "${result}"))
 
     monitor "setup" "$(basename "${package}")" "${result}"
   done
+
+  ((retval |= "${result}"))
 
   return "${retval}"
 }
@@ -266,15 +272,16 @@ setup_npm_packages() {
   local -a packages=("$@")
 
   local -i retval=0
-  for package in "${packages[@]}"; do
-    local -i result=0
+  local -i result=0
 
+  for package in "${packages[@]}"; do
     install_npm "${package}"
     ((result = $?))
-    ((retval |= "${result}"))
 
     monitor "setup" "${package}" "${result}"
   done
+
+  ((retval |= "${result}"))
 
   return "${retval}"
 }
@@ -291,6 +298,8 @@ cleanup_npm() {
 
   npm cache clean --force --silent
   ((result |= $?))
+
+  monitor "cleanup" "npm" "${result}"
 
   return "${result}"
 }


### PR DESCRIPTION
In the continuous integration setup script, the apt packages must be run first.