### PR TITLE
ci: assigning permissions to jobs in continuous release pipeline

### DIFF
--- a/.github/workflows/continuous-release.yml
+++ b/.github/workflows/continuous-release.yml
@@ -8,6 +8,7 @@ jobs:
   release:
     name: continuous-release
     runs-on: ubuntu-22.04
+    permissions: write-all
     steps:
       - name: Checkout Codebase
         uses: actions/checkout@v3


### PR DESCRIPTION
Modify the defauft permissions granted to `GITHUB_TOKEN` on protected branch with PR requirement to allow release with semantic-release.