### PR TITLE
fix(scripts): modify file system functionality `merge_file` with `touch` command

### DIFF
--- a/scripts/utils/fs.sh
+++ b/scripts/utils/fs.sh
@@ -82,6 +82,7 @@ merge_file() {
 
   local tmp="diff.txt"
 
+  touch "${dest}"
   diff --line-format="%L" -D MERGE -B "${src}" "${dest}" >"${tmp}"
   mv "${tmp}" "${dest}"
 }


### PR DESCRIPTION
The `diff` merge command is not applied if the destination file does not exist.